### PR TITLE
Fix code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/Chapter10/useSelect.go
+++ b/Chapter10/useSelect.go
@@ -33,9 +33,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	n1, _ := strconv.ParseInt(os.Args[1], 10, 64)
+	n1, err := strconv.ParseInt(os.Args[1], 10, 32)
+	if err != nil {
+		fmt.Printf("Invalid count value: %s\n", os.Args[1])
+		os.Exit(1)
+	}
 	count := int(n1)
-	n2, _ := strconv.ParseInt(os.Args[2], 10, 64)
+	n2, err := strconv.ParseInt(os.Args[2], 10, 32)
+	if err != nil {
+		fmt.Printf("Invalid max value: %s\n", os.Args[2])
+		os.Exit(1)
+	}
 	max := int(n2)
 
 	fmt.Printf("Going to create %d random numbers.\n", count)


### PR DESCRIPTION
Fixes [https://github.com/ibiscum/Go-Systems-Programming/security/code-scanning/2](https://github.com/ibiscum/Go-Systems-Programming/security/code-scanning/2)

To fix the problem, we need to ensure that the conversion from a 64-bit integer to an `int` type is safe. This can be achieved by checking that the parsed value is within the bounds of the `int` type before performing the conversion. If the value is out of bounds, we should handle the error appropriately, such as by setting a default value or returning an error.

The best way to fix the problem is to use the `strconv.ParseInt` function with a bit size of 32, which matches the size of the `int` type on most systems. This ensures that the parsed value is within the bounds of the `int` type. If the system uses a different size for `int`, we can adjust the bit size accordingly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
